### PR TITLE
Validate playbook and tasks

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -114,6 +114,16 @@ func TestValidatePlaybook(t *testing.T) {
 	if err := ParsedPlaybook2.Validate(); err == nil {
 		t.Errorf("Validation of incomplete playbook succeeded, expected error")
 	}
+
+	ParsedPlaybook3 := ParsedPlaybook1
+	ParsedPlaybook3.Tasks = []Task{
+		{
+			Manifests: []string{ManifestFilename},
+		},
+	}
+	if err := ParsedPlaybook3.Validate(); err == nil {
+		t.Errorf("Validation of playbook with a task missing a name succeeded, expected error")
+	}
 }
 
 func TestTaskManifestsPresent(t *testing.T) {
@@ -123,14 +133,7 @@ func TestTaskManifestsPresent(t *testing.T) {
 		errExpected bool
 	}{
 		{
-			"Validate Task Without Manifests",
-			Task{
-				Name: "task 0",
-			},
-			false,
-		},
-		{
-			"Validate Task With Missing Manifests",
+			"Task With Missing Manifests",
 			Task{
 				Name:      "task 1",
 				Manifests: []string{"pod0"},
@@ -138,10 +141,18 @@ func TestTaskManifestsPresent(t *testing.T) {
 			true,
 		},
 		{
-			"Validate Task With Existing Manifests",
+			"Task With Existing Manifests",
 			Task{
 				Name:      "task 2",
-				Manifests: []string{PlaybookFilename},
+				Manifests: []string{ManifestFilename},
+			},
+			false,
+		},
+		{
+			"Task With Only Pod Manifest",
+			Task{
+				Name:        "task 2",
+				PodManifest: ManifestFilename,
 			},
 			false,
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -176,7 +176,7 @@ func TestValidatePlaybook(t *testing.T) {
 		err := playbook.Validate()
 		if testcase.expectedErr == "" && err == nil { // expected success, got success
 		} else if testcase.expectedErr != err.Error() { // expected failure, got wrong failure
-			t.Errorf("Scenario %s\nExpected:\n%s\nActual:\n%s", testcase.scenario, err, testcase.expectedErr)
+			t.Errorf("Scenario %s\nExpected:\n%s\nActual:\n%s", testcase.scenario, testcase.expectedErr, err.Error())
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -105,9 +105,13 @@ func TestParsePlaybookIncomplete(t *testing.T) {
 }
 
 func TestValidatePlaybook(t *testing.T) {
-	ValidTask := Task{
+	ValidTask1 := Task{
 		Name:      "task",
 		Manifests: []string{ManifestFilename},
+	}
+	ValidTask2 := Task{
+		Name:        "task",
+		PodManifest: ManifestFilename,
 	}
 	InvalidTask1 := Task{
 		Manifests: []string{ManifestFilename},
@@ -125,13 +129,21 @@ func TestValidatePlaybook(t *testing.T) {
 			"Validate Valid Playbook",
 			Playbook{
 				Name:  "playbook 1",
-				Tasks: []Task{ValidTask},
+				Tasks: []Task{ValidTask1, ValidTask2},
 			},
 			false,
 		},
 		{
 			"Validate Empty Playbook",
 			Playbook{},
+			true,
+		},
+		{
+			"Validate Playbook With Zero Tasks",
+			Playbook{
+				Name:  "playbook 1",
+				Tasks: []Task{},
+			},
 			true,
 		},
 		{


### PR DESCRIPTION
This PR adds validation logic for a playbook yaml file. The following conditions are required for `playbook.Validate()` to return without err:
* that the Playbook has a populated Name field
* that the Playbook has more than zero items in Tasks array
* that each Task has a populated Name field
* that each Task has either a PodManifest string, or more than zero items in Manifests array
* that each PodManifest and Manifests is a filename that exists on disk

The yaml format has changed: pod_manifest was an array of strings, and is now a string.