### PR TITLE
instance.GetStatus implementation, API

### DIFF
--- a/instance/instance.go
+++ b/instance/instance.go
@@ -1,6 +1,10 @@
 package instance
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/namely/broadway/store"
+)
 
 // Status represents the lifecycle state of one instance
 type Status string
@@ -47,4 +51,13 @@ type Instance interface {
 
 	Attributes() *Attributes
 	Status() Status
+}
+
+// GetStatus retrieves the status of an instance
+func GetStatus(s store.Store, pID string, iID string) (Status, error) {
+	i, err := Get(pID, iID)
+	if err != nil {
+		return StatusNew, err
+	}
+	return i.Status(), nil
 }

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -1,0 +1,28 @@
+package instance
+
+import (
+	"testing"
+
+	"github.com/namely/broadway/store"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetStatusFailure(t *testing.T) {
+	s := store.New()
+
+	status, err := GetStatus(s, "test", "missing")
+	assert.Equal(t, StatusNew, status, "status of GetStatus(missing) should be StatusNew")
+	assert.Equal(t, "Instance does not exist.", err.Error(), "wrong err: GetStatus with bad arguments")
+}
+
+func TestGetStatusSuccess(t *testing.T) {
+	s := store.New()
+	i := New(s, &Attributes{PlaybookID: "test", ID: "present"})
+	err := i.Save()
+	assert.Nil(t, err)
+
+	status, err := GetStatus(s, "test", "present")
+	assert.Nil(t, err, "err of GetStatus with good arguments should be nil")
+	assert.Equal(t, StatusNew, status, "Status of GetStatus(new) should be StatusNew")
+}

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -16,13 +16,54 @@ func TestGetStatusFailure(t *testing.T) {
 	assert.Equal(t, "Instance does not exist.", err.Error(), "wrong err: GetStatus with bad arguments")
 }
 
+func TestGetDefaultStatus(t *testing.T) {
+	s := store.New()
+	testcases := []struct {
+		attrs Attributes
+	}{
+		{
+			Attributes{PlaybookID: "test", ID: "present"},
+		},
+	}
+
+	for _, testcase := range testcases {
+		i := New(s, &testcase.attrs)
+		err := i.Save()
+		assert.Nil(t, err)
+
+		status, err := GetStatus(s, testcase.attrs.PlaybookID, testcase.attrs.ID)
+		assert.Nil(t, err, "err of GetStatus with good arguments should be nil")
+		assert.Equal(t, StatusNew, status, "GetStatus() of newly created instance should be NewStatus")
+	}
+}
+
 func TestGetStatusSuccess(t *testing.T) {
 	s := store.New()
-	i := New(s, &Attributes{PlaybookID: "test", ID: "present"})
-	err := i.Save()
-	assert.Nil(t, err)
 
-	status, err := GetStatus(s, "test", "present")
-	assert.Nil(t, err, "err of GetStatus with good arguments should be nil")
-	assert.Equal(t, StatusNew, status, "Status of GetStatus(new) should be StatusNew")
+	testcases := []struct {
+		attrs Attributes
+	}{
+		{
+			Attributes{PlaybookID: "test", ID: "present", Status: StatusDeployed},
+		},
+		{
+			Attributes{PlaybookID: "test", ID: "present", Status: StatusDeploying},
+		},
+		{
+			Attributes{PlaybookID: "test", ID: "present", Status: StatusError},
+		},
+		{
+			Attributes{PlaybookID: "test", ID: "present", Status: StatusDeleting},
+		},
+	}
+
+	for _, testcase := range testcases {
+		i := New(s, &testcase.attrs)
+		err := i.Save()
+		assert.Nil(t, err)
+
+		status, err := GetStatus(s, testcase.attrs.PlaybookID, testcase.attrs.ID)
+		assert.Nil(t, err, "err of GetStatus with good arguments should be nil")
+		assert.Equal(t, testcase.attrs.Status, status, "GetStatus returned unexpected Status")
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -272,7 +272,7 @@ func TestGetStatusFailures(t *testing.T) {
 			"GET",
 			"/status/goodPlaybook/badInstance",
 			404,
-			"Instance badInstance not found",
+			"Instance does not exist.",
 		},
 	}
 
@@ -286,7 +286,7 @@ func TestGetStatusFailures(t *testing.T) {
 
 		server.ServeHTTP(w, req)
 
-		assert.Equal(t, w.Code, i.errCode)
+		assert.Equal(t, i.errCode, w.Code)
 
 		var errorResponse map[string]string
 
@@ -310,7 +310,7 @@ func TestGetStatusWithGoodPath(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/instances/goodPlaybook/goodInstance", nil)
+	req, err := http.NewRequest("GET", "/status/goodPlaybook/goodInstance", nil)
 	assert.Nil(t, err)
 
 	server := New(mem).Handler()


### PR DESCRIPTION
This PR will implement and test `instance.GetStatus(store, playbookID, instanceID)`

It will add an HTTP API handler for `status/:playbookID/:instanceID`