### PR TITLE
Run golint, go vet, errcheck on CI. Switch Alpine to Debian.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:1.6.0-alpine
 RUN apk add --update git && rm -rf /var/cache/apk/*
 
-RUN go get github.com/tools/godep
+RUN go get github.com/tools/godep github.com/kisielk/errcheck github.com/golang/lint/golint
 
 RUN mkdir -p /go/src/github.com/namely/broadway
 WORKDIR /go/src/github.com/namely/broadway

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-# registry.namely.tech/namely/broadway-dev:v4
+# registry.namely.tech/namely/broadway-dev:v5
 # If you change this file, or any of the dependencies, build a new image and
 # increase the version number.
-FROM golang:1.6.0-alpine
-RUN apk add --update git && rm -rf /var/cache/apk/*
+FROM golang:1.6.0
+RUN apt-get update && \
+    apt-get install --assume-yes git build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN go get github.com/tools/godep github.com/kisielk/errcheck github.com/golang/lint/golint
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ dependencies:
   pre:
     - curl -L https://github.com/docker/compose/releases/download/1.6.2/docker-compose-`uname -s`-`uname -m` > docker-compose
     - sudo mv docker-compose /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose
+    - go get -u github.com/kisielk/errcheck github.com/golang/lint/golint
   override:
     - docker login -e="." -u=$DOCKER_USER -p=$DOCKER_PASSWORD registry.namely.tech
     - docker-compose up -d
@@ -15,6 +16,24 @@ dependencies:
 test:
   override:
     - docker-compose run test go test -v ./...
+    - golint 
+    - golint ./instance
+    - golint ./manifest
+    - golint ./playbook
+    - golint ./server
+    - golint ./store
+    - go vet 
+    - go vet ./instance
+    - go vet ./manifest
+    - go vet ./playbook
+    - go vet ./server
+    - go vet ./store
+    - errcheck 
+    - errcheck ./instance
+    - errcheck ./manifest
+    - errcheck ./playbook
+    - errcheck ./server
+    - errcheck ./store
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ dependencies:
   pre:
     - curl -L https://github.com/docker/compose/releases/download/1.6.2/docker-compose-`uname -s`-`uname -m` > docker-compose
     - sudo mv docker-compose /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose
-    - go get -u github.com/kisielk/errcheck github.com/golang/lint/golint
   override:
     - docker login -e="." -u=$DOCKER_USER -p=$DOCKER_PASSWORD registry.namely.tech
     - docker-compose up -d
@@ -16,24 +15,24 @@ dependencies:
 test:
   override:
     - docker-compose run test go test -v ./...
-    - golint 
-    - golint ./instance
-    - golint ./manifest
-    - golint ./playbook
-    - golint ./server
-    - golint ./store
-    - go vet 
-    - go vet ./instance
-    - go vet ./manifest
-    - go vet ./playbook
-    - go vet ./server
-    - go vet ./store
-    - errcheck 
-    - errcheck ./instance
-    - errcheck ./manifest
-    - errcheck ./playbook
-    - errcheck ./server
-    - errcheck ./store
+    - docker-compose run test golint
+    - docker-compose run test golint ./instance
+    - docker-compose run test golint ./manifest
+    - docker-compose run test golint ./playbook
+    - docker-compose run test golint ./server
+    - docker-compose run test golint ./store
+    - docker-compose run test go vet
+    - docker-compose run test go vet ./instance
+    - docker-compose run test go vet ./manifest
+    - docker-compose run test go vet ./playbook
+    - docker-compose run test go vet ./server
+    - docker-compose run test go vet ./store
+    - docker-compose run test errcheck
+    - docker-compose run test errcheck ./instance
+    - docker-compose run test errcheck ./manifest
+    - docker-compose run test errcheck ./playbook
+    - docker-compose run test errcheck ./server
+    - docker-compose run test errcheck ./store
 
 deployment:
   production:


### PR DESCRIPTION
* I have not yet found any way to exclude the `vendor` folder when running against `./...`, or a way to specify multiple packages in one command, thus the many commands
* `go vet` and `errcheck` return 1 when they find problems; `golint` returns 0