### PR TITLE
Properly handle Slack commands

### DIFF
--- a/services/slack_command_handler.go
+++ b/services/slack_command_handler.go
@@ -20,6 +20,14 @@ func (c *dummyCommand) Execute() error {
 	return errors.New("foo")
 }
 
+type deployCommand struct {
+	args []string
+}
+
+func (c *deployCommand) Execute() error {
+	return errors.New("foo")
+}
+
 type setvarCommand struct {
 	args []string
 	Vars map[string]string

--- a/services/slack_command_handler.go
+++ b/services/slack_command_handler.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// SlackCommand represents a user command that came in from Slack
+type SlackCommand interface {
+	Execute() error
+}
+
+type dummyCommand struct {
+	args []string
+}
+
+func (c *dummyCommand) Execute() error {
+	return errors.New("foo")
+}
+
+type setvarCommand struct {
+	args []string
+	Vars map[string]string
+	is   *InstanceService
+}
+
+func (c *setvarCommand) Execute() error {
+	c.Vars = make(map[string]string)
+	kvs := c.args[3:len(c.args)] // from e.g. "setvar foo bar var1=val1 var2=val2"
+	for _, kv := range kvs {
+		kv = strings.TrimPrefix(kv, "=")
+		kv = strings.TrimSuffix(kv, "=")
+		tmp := strings.Split(kv, "=")
+		if len(tmp) != 2 {
+			glog.Warning("Setvar tried to parse badly formatted variable: " + kv)
+			return errors.New("This is not the proper syntax. ex: var1=val1")
+		}
+		c.Vars[tmp[0]] = tmp[1]
+	}
+	i, err := c.is.Show(c.args[1], c.args[2])
+	if err != nil {
+		glog.Warningf("Cannot setvars for not found instance %s/%s\n", c.args[1], c.args[2])
+		return errors.New("Instance not found")
+	}
+	i.Vars = c.Vars
+	err = c.is.repo.Save(i)
+	if err != nil {
+		glog.Errorf("Failed to save instance %s/%s with new vars\n", c.args[1], c.args[2])
+		return errors.New("Instance not updated")
+	}
+	return nil
+}
+
+// BuildSlackCommand takes a string and some context and creates a SlackCommand
+func BuildSlackCommand(payload string, is *InstanceService) SlackCommand {
+	terms := strings.Split(payload, " ")
+	switch terms[0] {
+	case "dummy":
+		return &dummyCommand{args: terms}
+	case "setvar": // setvar foo bar var1=val1 var2=val2
+		return &setvarCommand{args: terms, is: is}
+		// case "help"
+	default:
+		return &dummyCommand{args: terms}
+	}
+}

--- a/services/slack_command_handler_test.go
+++ b/services/slack_command_handler_test.go
@@ -11,6 +11,11 @@ import (
 
 func TestExecuteSetvar(t *testing.T) {
 	is := NewInstanceService(store.New())
+	i := &instance.Instance{
+		PlaybookID: "foo",
+		ID:         "bar",
+	}
+	is.repo.Save(i)
 	testcases := []struct {
 		Scenario  string
 		Arguments []string
@@ -90,4 +95,22 @@ func TestSetvar(t *testing.T) {
 	c.Execute()
 	i2, _ := is.Show("balls", "bowling")
 	assert.Equal(t, "10", i2.Vars["pins"], "Expected setvar to update the instance")
+}
+
+func TestDeploy(t *testing.T) {
+	i := &instance.Instance{
+		PlaybookID: "balls",
+		ID:         "tennis",
+	}
+	is := NewInstanceService(store.New())
+	is.repo.Save(i)
+
+	c := setvarCommand{
+		args: []string{"deploy", "balls", "tennis"},
+		is:   is,
+	}
+	c.Execute()
+	i2, _ := is.Show("balls", "tennis")
+	assert.Equal(t, instance.StatusDeployed, i2.Status, "Expected deploy to mark the instance as deployed")
+
 }

--- a/services/slack_command_handler_test.go
+++ b/services/slack_command_handler_test.go
@@ -1,0 +1,84 @@
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/namely/broadway/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecuteSetvar(t *testing.T) {
+	is := NewInstanceService(store.New())
+	testcases := []struct {
+		Scenario  string
+		Arguments []string
+		Expected  map[string]string
+		E         error
+	}{
+		{
+			"When a valid set of arguments been passed",
+			[]string{"setvar", "foo", "bar", "var1=val1"},
+			map[string]string{"var1": "val1"},
+			nil,
+		},
+		{
+			"When an argument text just has a key",
+			[]string{"setvar", "foo", "bar", "var1="},
+			map[string]string{},
+			errors.New("This is not the proper syntax. ex: var1=val1"),
+		},
+		{
+			"When an argument text just has a value",
+			[]string{"setvar", "foo", "bar", "=val1"},
+			map[string]string{},
+			errors.New("This is not the proper syntax. ex: var1=val1"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		command := &setvarCommand{
+			args: testcase.Arguments,
+			is:   is,
+		}
+		err := command.Execute()
+		assert.Equal(t, testcase.E, err, testcase.Scenario)
+		assert.Equal(t, testcase.Expected, command.Vars, testcase.Scenario)
+	}
+}
+
+/*
+func TestBuildSlackCommand(t *testing.T) {
+	is := NewInstanceService(store.New())
+	testcases := []struct {
+		text         string
+		expectedType SlackCommand
+	}{
+		{
+			"dummy",
+			dummyCommand,
+		},
+		{
+			"help",
+			helpCommand,
+		},
+		{
+			"setvar",
+			setvarCommand,
+		},
+	}
+	for _, testcase := range testcases {
+		c := BuildSlackCommand(testcase.text, is)
+		assert.True(t, c.(type) == testcase.expectedType, "Built command was not type "+testcase.expectedType)
+	}
+}
+*/
+
+/*
+func TestSetvar(t *testing.T){
+	i := &broadway.Instance {
+		playbookID: "foo",
+		ID: "bar",
+	}
+}
+*/

--- a/services/slack_command_handler_test.go
+++ b/services/slack_command_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/namely/broadway/instance"
 	"github.com/namely/broadway/store"
 	"github.com/stretchr/testify/assert"
 )
@@ -74,11 +75,19 @@ func TestBuildSlackCommand(t *testing.T) {
 }
 */
 
-/*
-func TestSetvar(t *testing.T){
-	i := &broadway.Instance {
-		playbookID: "foo",
-		ID: "bar",
+func TestSetvar(t *testing.T) {
+	i := &instance.Instance{
+		PlaybookID: "balls",
+		ID:         "bowling",
 	}
+	is := NewInstanceService(store.New())
+	is.repo.Save(i)
+
+	c := setvarCommand{
+		args: []string{"setvar", "balls", "bowling", "pins=10"},
+		is:   is,
+	}
+	c.Execute()
+	i2, _ := is.Show("balls", "bowling")
+	assert.Equal(t, "10", i2.Vars["pins"], "Expected setvar to update the instance")
 }
-*/


### PR DESCRIPTION
This PR moves processing logic for Slack commands into `services/slack-_command_handler.go`

Callers will invoke `services.BuildSlackCommand()` to get a SlackCommand object.
When `.Execute()` is called on this object, the appropriate action will be taken.