### PR TITLE
add age to info, sort vars

### DIFF
--- a/services/deployment.go
+++ b/services/deployment.go
@@ -29,7 +29,7 @@ func NewDeploymentService(s store.Store, ps map[string]*deployment.Playbook, ms 
 	}
 }
 
-func vars(i *instance.Instance) map[string]string {
+func varMap(i *instance.Instance) map[string]string {
 	vs := map[string]string{}
 	for k, v := range i.Vars {
 		vs[k] = v
@@ -60,7 +60,7 @@ func (d *DeploymentService) DeployAndNotify(i *instance.Instance) error {
 		return err
 	}
 
-	deployer, err := deployment.NewKubernetesDeployment(config, playbook, vars(i), d.manifests)
+	deployer, err := deployment.NewKubernetesDeployment(config, playbook, varMap(i), d.manifests)
 	if err != nil {
 		msg := fmt.Sprintf("Can't deploy %s/%s: Internal error", i.PlaybookID, i.ID)
 		notify(i, msg)
@@ -137,7 +137,7 @@ func sendDeploymentNotification(i *instance.Instance) error {
 	tp, ok := pb.Messages["deployed"]
 	if ok {
 		b := new(bytes.Buffer)
-		err := template.Must(template.New("deployed").Parse(tp)).Execute(b, vars(i))
+		err := template.Must(template.New("deployed").Parse(tp)).Execute(b, varMap(i))
 		if err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func (d *DeploymentService) DeleteAndNotify(i *instance.Instance) error {
 		return err
 	}
 
-	deployer, err := deployment.NewKubernetesDeployment(config, playbook, vars(i), d.manifests)
+	deployer, err := deployment.NewKubernetesDeployment(config, playbook, varMap(i), d.manifests)
 	if err != nil {
 		msg := fmt.Sprintf("Can't delete %s/%s: Internal error", i.PlaybookID, i.ID)
 		notify(i, msg)

--- a/services/instance.go
+++ b/services/instance.go
@@ -192,7 +192,7 @@ func sendNotification(update bool, i *instance.Instance) error {
 	}
 	if ok {
 		b := new(bytes.Buffer)
-		err := template.Must(template.New("created").Parse(tp)).Execute(b, vars(i))
+		err := template.Must(template.New("created").Parse(tp)).Execute(b, varMap(i))
 		if err != nil {
 			return err
 		}

--- a/services/slack.go
+++ b/services/slack.go
@@ -193,9 +193,9 @@ func (c *infoCommand) Execute() (string, error) {
 		glog.Error(msg)
 		return msg, err
 	}
-	vv := Vars{}
+	vv := varSlice{}
 	for k, val := range i.Vars {
-		v := Var{
+		v := varKV{
 			k: k,
 			v: val,
 		}

--- a/services/slack.go
+++ b/services/slack.go
@@ -193,13 +193,22 @@ func (c *infoCommand) Execute() (string, error) {
 		glog.Error(msg)
 		return msg, err
 	}
+	vv := Vars{}
+	for k, val := range i.Vars {
+		v := Var{
+			k: k,
+			v: val,
+		}
+		vv = append(vv, v)
+	}
+	sortVars(vv)
 	m1 := fmt.Sprintf("Playbook: %s\n", wrapQuotes(i.PlaybookID))
 	m2 := fmt.Sprintf("Instance: %s\n", wrapQuotes(i.ID))
 	m3 := fmt.Sprintf("Age: %s\n", wrapQuotes(fmtAge(i.Created)))
 	m4 := fmt.Sprintf("Status: %s\n", wrapQuotes(string(i.Status)))
 	m5 := "Vars:\n"
-	for k, v := range i.Vars {
-		m5 += fmt.Sprintf("  - %s: %s\n", k, wrapQuotes(v))
+	for _, vr := range vv {
+		m5 += fmt.Sprintf("  - %s: %s\n", vr.k, wrapQuotes(vr.v))
 	}
 	msg := m1 + m2 + m3 + m4 + m5
 	return msg, nil

--- a/services/slack.go
+++ b/services/slack.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/namely/broadway/deployment"
@@ -194,18 +195,32 @@ func (c *infoCommand) Execute() (string, error) {
 	}
 	m1 := fmt.Sprintf("Playbook: %s\n", wrapQuotes(i.PlaybookID))
 	m2 := fmt.Sprintf("Instance: %s\n", wrapQuotes(i.ID))
-	m3 := fmt.Sprintf("Status: %s\n", wrapQuotes(string(i.Status)))
-	m4 := "Vars:\n"
+	m3 := fmt.Sprintf("Age: %s\n", wrapQuotes(fmtAge(i.Created)))
+	m4 := fmt.Sprintf("Status: %s\n", wrapQuotes(string(i.Status)))
+	m5 := "Vars:\n"
 	for k, v := range i.Vars {
-		m4 += fmt.Sprintf("  - %s: %s\n", k, wrapQuotes(v))
+		m5 += fmt.Sprintf("  - %s: %s\n", k, wrapQuotes(v))
 	}
-	// fmt.Sprintf("Playbook: %s\n", i.PlaybookID())
-	msg := m1 + m2 + m3 + m4
+	msg := m1 + m2 + m3 + m4 + m5
 	return msg, nil
 }
 
 func wrapQuotes(s string) string {
 	return fmt.Sprintf("\"%s\"", s)
+}
+
+func fmtAge(d0 int64) string {
+	t0 := time.Unix(d0, 0)
+	age := time.Since(t0)
+	switch {
+	case age > 24*60*time.Minute:
+		return fmt.Sprintf("%dd", int(age.Hours()/24))
+	case age > 60*time.Minute:
+		return fmt.Sprintf("%dh", int(age.Minutes()/60))
+	case age > 60*time.Second:
+		return fmt.Sprintf("%dm", int(age.Minutes()))
+	}
+	return fmt.Sprintf("%ds", int(age.Seconds()))
 }
 
 // BuildSlackCommand takes a string and some context and creates a SlackCommand

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -257,7 +257,7 @@ func TestInfoExecute(t *testing.T) {
 				PlaybookID: "helloplaybook",
 				ID:         "showinfo",
 				Status:     instance.StatusDeployed,
-				Vars:       map[string]string{"bird": "albatross"},
+				Vars:       map[string]string{"word": "phlegmatic", "bird": "albatross"},
 			},
 			"info helloplaybook showinfo",
 			`Playbook: "helloplaybook"
@@ -266,7 +266,7 @@ Age: "3s"
 Status: "deployed"
 Vars:
   - bird: "albatross"
-  - word: ""
+  - word: "phlegmatic"
 `,
 			nil,
 		},

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"testing"
+	"time"
 
 	"github.com/namely/broadway/deployment"
 	"github.com/namely/broadway/instance"
@@ -261,6 +262,7 @@ func TestInfoExecute(t *testing.T) {
 			"info helloplaybook showinfo",
 			`Playbook: "helloplaybook"
 Instance: "showinfo"
+Age: "3s"
 Status: "deployed"
 Vars:
   - bird: "albatross"
@@ -286,6 +288,8 @@ Vars:
 	is := NewInstanceService(store.New())
 	for _, testcase := range testcases {
 		_, err := is.CreateOrUpdate(testcase.Instance)
+		// CreateOrUpdate always resets instance.Created so we can't mock it:
+		time.Sleep(3 * time.Second)
 		if err != nil {
 			t.Log(err)
 		}

--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -288,8 +288,6 @@ Vars:
 	is := NewInstanceService(store.New())
 	for _, testcase := range testcases {
 		_, err := is.CreateOrUpdate(testcase.Instance)
-		// CreateOrUpdate always resets instance.Created so we can't mock it:
-		time.Sleep(3 * time.Second)
 		if err != nil {
 			t.Log(err)
 		}
@@ -300,6 +298,8 @@ Vars:
 				"helloplaybook": {ID: "showinfo"},
 			},
 		)
+		// CreateOrUpdate always resets instance.Created so we can't mock it:
+		time.Sleep(3 * time.Second)
 		msg, err := command.Execute()
 		assert.IsType(t, testcase.ExpectedErr, err, testcase.Scenario)
 		assert.Equal(t, testcase.ExpectedMsg, msg, testcase.Scenario)

--- a/services/sortvars.go
+++ b/services/sortvars.go
@@ -7,18 +7,18 @@ import (
 
 // Implement sort.Interface for Vars:
 
-// Vars is a slice of instance variables
-type Vars []Var
+// varSlice is a slice of instance variables
+type varSlice []varKV
 
-// Var is a single instance variable with key k, value v
-type Var struct {
+// varKV is a single instance variable with key k, value v
+type varKV struct {
 	k string
 	v string
 }
 
 // Less returns true if vv[i].k is alphabetically before vv[j].k
-func (vv Vars) Less(i, j int) bool {
-	xx := []Var(vv)
+func (vv varSlice) Less(i, j int) bool {
+	xx := []varKV(vv)
 	if len(xx[i].k) == 0 {
 		return true
 	}
@@ -29,14 +29,14 @@ func (vv Vars) Less(i, j int) bool {
 }
 
 // Len returns the length of vv
-func (vv Vars) Len() int {
-	xx := []Var(vv)
+func (vv varSlice) Len() int {
+	xx := []varKV(vv)
 	return len(xx)
 }
 
 // Swap swaps two indices of vv
-func (vv Vars) Swap(i, j int) {
-	xx := []Var(vv)
+func (vv varSlice) Swap(i, j int) {
+	xx := []varKV(vv)
 	// *vv[i], *vv[j] = *vv[j], *vv[i]
 	xx[i], xx[j] = xx[j], xx[i]
 }
@@ -44,6 +44,6 @@ func (vv Vars) Swap(i, j int) {
 // sortVars takes a slice of 2-ary arrays
 // each array is [k, v]
 // returned slice will be sorted alphabetically by k
-func sortVars(vv Vars) {
+func sortVars(vv varSlice) {
 	sort.Sort(vv)
 }

--- a/services/sortvars.go
+++ b/services/sortvars.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"sort"
+	"strings"
+)
+
+// Implement sort.Interface for Vars:
+
+// Vars is a slice of instance variables
+type Vars []Var
+
+// Var is a single instance variable with key k, value v
+type Var struct {
+	k string
+	v string
+}
+
+// Less returns true if vv[i].k is alphabetically before vv[j].k
+func (vv Vars) Less(i, j int) bool {
+	xx := []Var(vv)
+	if len(xx[i].k) == 0 {
+		return true
+	}
+	if len(xx[j].k) == 0 {
+		return false
+	}
+	return strings.ToLower(xx[i].k)[0] < strings.ToLower(xx[j].k)[0]
+}
+
+// Len returns the length of vv
+func (vv Vars) Len() int {
+	xx := []Var(vv)
+	return len(xx)
+}
+
+// Swap swaps two indices of vv
+func (vv Vars) Swap(i, j int) {
+	xx := []Var(vv)
+	// *vv[i], *vv[j] = *vv[j], *vv[i]
+	xx[i], xx[j] = xx[j], xx[i]
+}
+
+// sortVars takes a slice of 2-ary arrays
+// each array is [k, v]
+// returned slice will be sorted alphabetically by k
+func sortVars(vv Vars) {
+	sort.Sort(vv)
+}

--- a/services/sortvars.go
+++ b/services/sortvars.go
@@ -25,7 +25,7 @@ func (vv Vars) Less(i, j int) bool {
 	if len(xx[j].k) == 0 {
 		return false
 	}
-	return strings.ToLower(xx[i].k)[0] < strings.ToLower(xx[j].k)[0]
+	return strings.ToLower(xx[i].k) < strings.ToLower(xx[j].k)
 }
 
 // Len returns the length of vv

--- a/services/sortvars_test.go
+++ b/services/sortvars_test.go
@@ -7,22 +7,22 @@ import (
 )
 
 func TestSortVars(t *testing.T) {
-	foo := Var{
-		k: "foo",
-		v: "bar",
+	foo1 := Var{
+		k: "food",
+		v: "clamato",
 	}
 
-	goo := Var{
-		k: "goo",
-		v: "car",
+	foo2 := Var{
+		k: "fool",
+		v: "motley",
 	}
 
-	hoo := Var{
-		k: "hoo",
-		v: "dar",
+	foo3 := Var{
+		k: "goal",
+		v: "goooooooooooooooooooooooal",
 	}
-	v1 := Vars{foo, goo, hoo}
-	v2 := Vars{goo, hoo, foo}
+	v1 := Vars{foo1, foo2, foo3}
+	v2 := Vars{foo2, foo3, foo1}
 
 	testcases := []struct {
 		scenario string

--- a/services/sortvars_test.go
+++ b/services/sortvars_test.go
@@ -7,27 +7,27 @@ import (
 )
 
 func TestSortVars(t *testing.T) {
-	foo1 := Var{
+	foo1 := varKV{
 		k: "food",
 		v: "clamato",
 	}
 
-	foo2 := Var{
+	foo2 := varKV{
 		k: "fool",
 		v: "motley",
 	}
 
-	foo3 := Var{
+	foo3 := varKV{
 		k: "goal",
 		v: "goooooooooooooooooooooooal",
 	}
-	v1 := Vars{foo1, foo2, foo3}
-	v2 := Vars{foo2, foo3, foo1}
+	v1 := varSlice{foo1, foo2, foo3}
+	v2 := varSlice{foo2, foo3, foo1}
 
 	testcases := []struct {
 		scenario string
-		in       Vars
-		out      Vars
+		in       varSlice
+		out      varSlice
 	}{
 		{
 			scenario: "it sorts in order vars",

--- a/services/sortvars_test.go
+++ b/services/sortvars_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortVars(t *testing.T) {
+	foo := Var{
+		k: "foo",
+		v: "bar",
+	}
+
+	goo := Var{
+		k: "goo",
+		v: "car",
+	}
+
+	hoo := Var{
+		k: "hoo",
+		v: "dar",
+	}
+	v1 := Vars{foo, goo, hoo}
+	v2 := Vars{goo, hoo, foo}
+
+	testcases := []struct {
+		scenario string
+		in       Vars
+		out      Vars
+	}{
+		{
+			scenario: "it sorts in order vars",
+			in:       v1,
+			out:      v1,
+		},
+		{
+			scenario: "it sorts out of order vars",
+			in:       v2,
+			out:      v1,
+		},
+	}
+
+	for _, tc := range testcases {
+		out := tc.in
+		sortVars(out)
+		assert.Equal(t, tc.out, out, tc.scenario)
+	}
+
+}


### PR DESCRIPTION
Adds age since `instance.Created` timestamp to the output of `/bw info`

Be aware, this timestamp gets reset when the instance is *updated* too

This also sorts the `Vars` alphabetically by key